### PR TITLE
Use project_plugins for rebar3_archive_plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -29,4 +29,4 @@
             {test, [{plugins, [{coveralls, "1.4.0"},
                                {rebar3_elvis_plugin, "0.0.4"}]}]}]}.
 
-{plugins, [{rebar3_archive_plugin, "0.0.2"}]}.
+{project_plugins, [{rebar3_archive_plugin, "0.0.2"}]}.


### PR DESCRIPTION
rebar3_archive_plugin uses old version of elvis library which breaks rebar3 lint plugin.
project_plugin directive "defines plugins that will only be available when the project is being built directly by rebar3 commands, as in running rebar3 from the top level directory of the application/project."
This will fix old elvis dependency propagation problem